### PR TITLE
fix: update to use alias instead of ID

### DIFF
--- a/pingpong-python-sdk/README.md
+++ b/pingpong-python-sdk/README.md
@@ -11,7 +11,7 @@ from pingpongsdk.deployments.model import CreateDeployment
 pingpong = PingPong()
 deployment = pingpong.deployments.create(deployment=CreateDeployment(
     name="example-deployment",
-    model='pingpongai/<model-name>',
+    model='pingpongai/ai-image-scan',
     args={
         'input_image_file': 'https://cdn.mediamagic.dev/media/eb341446-be53-11ed-b4a8-66139910f724.jpg',
     }

--- a/pingpong-python-sdk/example/example.py
+++ b/pingpong-python-sdk/example/example.py
@@ -6,25 +6,18 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from pingpongsdk.deployments.model import CreateDeployment
 from pingpongsdk import PingPong
 
-
-_API_KEY = os.getenv("X_MEDIAMAGIC_KEY")
-
-
 if __name__ == '__main__':
-    pingpong = PingPong(_API_KEY)
-
-    model = pingpong.models.get_by_id(id='4954c9fd-7fc2-4d4c-a036-f23f7605fa69')
-
+    pingpong = PingPong()
     try:
         deployment = pingpong.deployments.create(deployment=CreateDeployment(
             name="example-deployment",
-            model_id=model.id,
+            model='pingponai/background-removal',
             args={
-                'input_image_file': 'https://cdn.mediamagic.dev/media/eb341446-be53-11ed-b4a8-66139910f724.jpg',
+                'input': 'https://cdn.mediamagic.dev/media/eb341446-be53-11ed-b4a8-66139910f724.jpg',
             }
         ))
 
-        print(model.name)
+        print(deployment.name)
         print(deployment.job.results)
     except Exception as e:
         print(e)

--- a/pingpong-python-sdk/pingpongsdk/__init__.py
+++ b/pingpong-python-sdk/pingpongsdk/__init__.py
@@ -4,7 +4,7 @@ from .deployments.deployments import Deployments
 from .models.models import Models
 
 
-_API_KEY = os.getenv('X_MEDIAMAGIC_KEY')
+_API_KEY = os.getenv('X_PINGPONG_KEY')
 
 
 class PingPong():
@@ -19,4 +19,4 @@ class PingPong():
 
     def __init__(self, api_key=_API_KEY):
         self.models = Models(api_key=api_key)
-        self.deployments = Deployments(api_key=api_key)
+        self.deployments = Deployments(api_key=api_key, models=self.models)

--- a/pingpong-python-sdk/pingpongsdk/deployments/deployments.py
+++ b/pingpong-python-sdk/pingpongsdk/deployments/deployments.py
@@ -1,11 +1,13 @@
 from ..shared.client.client import Client
-from .model import Deployment, dto, CreateDeployment
+from .model import Deployment, dto, request_dto, CreateDeployment
 
 from dataclasses import asdict
 
 
 class Deployments(Client):
-    def __init__(self, api_key: str) -> None:
+
+    def __init__(self, api_key: str, models) -> None:
+        self.models = models
         super().__init__(api_key)
 
 
@@ -22,9 +24,12 @@ class Deployments(Client):
         create - create a new Deployment
         """
         try:
-            deployment = super().post("/api/v1/deployments", asdict(deployment))
-            print(deployment)
-            # return dto(deployment)
+            model = self.models.get_by_alias(deployment.model)
+            id = model.id
+            request = request_dto(id, deployment)
+
+            deployment = super().post("/api/v1/deployments", request)
+            return dto(deployment)
         except Exception as e:
             raise Exception('error creating deployment %s' % e)
 

--- a/pingpong-python-sdk/pingpongsdk/deployments/model.py
+++ b/pingpong-python-sdk/pingpongsdk/deployments/model.py
@@ -10,23 +10,29 @@ class Job:
 @dataclass
 class Deployment:
     id: str
-    model_id: str
+    model: str
     job: Job
 
 
 @dataclass
 class CreateDeployment:
-    model_id: str
+    model: str
     args: dict
     name: str
 
     def dict(self):
         return super().dict()
 
+def request_dto(id: str, m: CreateDeployment) -> dict:
+    return {
+        'model_id': id,
+        'args': m.args,
+        'name': m.name,
+    }
 
 def dto(m: dict) -> Deployment:
     return Deployment(
         id=m.get('id'),
-        model_id=m.get('model_id'),
+        model=m.get('alias'),
         job=m.get('job'),
     )

--- a/pingpong-python-sdk/pingpongsdk/deployments/test_deployments.py
+++ b/pingpong-python-sdk/pingpongsdk/deployments/test_deployments.py
@@ -12,7 +12,7 @@ def test_can_create_deployment():
     deployment_client = Deployments(api_key=_API_KEY)
     deployment = deployment_client.create(deployment=CreateDeployment(
         name="test-deployment",
-        model_id="4954c9fd-7fc2-4d4c-a036-f23f7605fa69",
+        model="pingponai/background-removal",
         args={
             'input_image_file': 'https://cdn.mediamagic.dev/media/eb341446-be53-11ed-b4a8-66139910f724.jpg',
         },

--- a/pingpong-python-sdk/pingpongsdk/models/model.py
+++ b/pingpong-python-sdk/pingpongsdk/models/model.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 class Model:
     id: str
     name: str
+    alias: str
     description: str
     example_outputs: list[str]
     args: list[dict]

--- a/pingpong-python-sdk/pingpongsdk/models/models.py
+++ b/pingpong-python-sdk/pingpongsdk/models/models.py
@@ -11,6 +11,7 @@ def dto(m: list) -> Model:
         args=m.get('args'),
         video=m.get('video'),
         example_outputs=m.get('example_outputs'),
+        alias=m.get('alias'),
     )
 
 
@@ -36,3 +37,15 @@ class Models(Client):
         """
         model = super().get("/api/v1/models/%s" % id)
         return dto(model)
+
+    def get_by_alias(self, alias: str):
+        """
+        get_by_alias - get a model by alias
+        """
+        try:
+            org, model = alias.split("/")
+            path = "/api/v1/models/alias/%s/%s" % (org, model)
+            model = super().get(path)
+            return dto(model)
+        except Exception as e:
+            raise Exception('error getting model %s' % e)

--- a/pingpong-python-sdk/pingpongsdk/shared/client/client.py
+++ b/pingpong-python-sdk/pingpongsdk/shared/client/client.py
@@ -33,6 +33,7 @@ class Client:
                 'x-mediamagic-key': self._api_key,
                 'Accept': 'application/json',
             })
+            print(response.json())
             response.raise_for_status()
             return response.json()
         except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
We were previously using the 'model id', which could be a little confusing for user's. So this update makes the Python SDK use the alias instead